### PR TITLE
add cost control policy

### DIFF
--- a/max-100-per-month.sentinel
+++ b/max-100-per-month.sentinel
@@ -1,0 +1,8 @@
+import "tfrun"
+import "decimal"
+
+delta_monthly_cost = decimal.new(tfrun.cost_estimate.delta_monthly_cost)
+
+main = rule {
+  delta_monthly_cost.less_than(100)
+}

--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -4,3 +4,7 @@
 policy "allowed-terraform-version" {
   enforcement_level = "soft-mandatory"
 }
+
+policy "max-100-per-month" {
+  enforcement_level = "soft-mandatory"
+}


### PR DESCRIPTION
Add a Sentinel policy to limit incremental costs to $100/mo. Operators with override privileges are permitted to override the policy result.